### PR TITLE
トークンリストの型や操作する関数を変更した

### DIFF
--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -119,10 +119,10 @@ t_token	*lex(char *input)
 		tmp->next = next_token(l);
 		if (!tmp->next)
 		{
-			token_lstclear(&token);
+			token_lstclear(token.next);
 			return (NULL);
 		}
-		if (tmp->type == EOL)
+		if (tmp->next->type == EOL)
 			break ;
 		tmp = tmp->next;
 	}


### PR DESCRIPTION
- Fix: '=' is need to delimiter
- Add: t_tokenizer
- Add:  slit subshell newline
- Add: next_token() returns EOL token, delete '\n' before RPAREN
- Update: const len_start, singly-linked list
- Remove: token_lstadd_back() and token_lstlast
- Update: test function stop at TEST_EOL
- Update: token_lstclear() argument, EOL judge

## Purpose
lexerにかなりの変更があり、挙動に問題がないか確認するため。

## Effect
以下のような変更を行うことで、繰り返しになっている無駄な処理や変数を削減できる。
- `const size_t	len_start = l->position;` でスタート位置を`const`にした。
- 上記変更に伴い、`str_start`変数を削除し、`token->literal.start = &(l->input[len_start]);` のように文字列のポインタを返すようにした。
- `t_token	*new_token(t_token_type token_type, t_lexer *l, size_t len, size_t len_start)`のように`new_token()`関数の引数に文字列のスタート位置を加え、tokenを返す各関数内の不要な`read_char()`を削減した。
- `lexer()`関数内において、`token_lstadd_back(), token_lstlast()`を削除し、ループのたびに最後の要素を見に行く、という無駄な処理を削減した。(by tacomea's `ft_lstmap()`)
- parserの仕様変更に伴い、token listを双方向リストから単方向リストに変更した。
- テスト関数において、一々tokenの数を数えてテストするのはめんどくさいので、`TEST_EOL`という定数が来るまでループを回すようにし、テスト追加の際の手間を削減した。

## Test
```bash
$ pwd
/lexer/test
$ make
```


## Memo
前のPRで変更後のApproveもらう前にmergeしちゃってすみません！！
一応この変更は別でPR残しておいた方がいいと思ったので、新しく作っておきます。