### PR TITLE
リダイレクト後の`NEWLINE`トークン

### DIFF
--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -13,6 +13,8 @@ t_lexer *new_lexer(char *input)
 	l->input = input;
 	l->position = 0;
 	l->read_position = 0;
+	l->is_subshell = false;
+	l->is_redirect = false;
 	return l;
 }
 
@@ -112,7 +114,6 @@ t_token	*lex(char *input)
 		return (NULL);
 	token.next = NULL;
 	tmp = &token;
-	l->is_subshell = false;
 	read_char(l);
 	while (1)
 	{

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -26,6 +26,7 @@ typedef struct s_lexer
 	size_t	read_position;
 	char	ch;
 	bool	is_subshell;
+	bool	is_redirect;
 }	t_lexer;
 
 typedef int	t_bool;
@@ -51,6 +52,5 @@ t_token	*new_token_newline(t_lexer *lexer);
 
 // lexer_list.c
 void	token_lstclear(t_token *lst);
-
 
 #endif //LEXER_H

--- a/lexer/lexer_new_token.c
+++ b/lexer/lexer_new_token.c
@@ -13,6 +13,9 @@ t_token	*new_token(t_token_type token_type, t_lexer *l, size_t len, size_t len_s
 	token->literal.start = &(l->input[len_start]);
 	token->literal.len = len;
 	token->next = NULL;
+	if (token_type == REDIRECT_IN || token_type == REDIRECT_OUT
+		|| token_type == HEREDOC || token_type == REDIRECT_APPEND)
+		l->is_redirect = true;
 	return (token);
 }
 
@@ -96,13 +99,19 @@ t_token	*new_token_newline(t_lexer *l)
 	t_token			*token;
 	const size_t	len_start = l->position;
 	size_t			newline_num;
+	t_token_type	newline_type;
 
 	newline_num = 0;
+	newline_type = ILLEGAL;
 	while (l->ch != '\n')
 	{
 		read_char(l);
 		newline_num++;
 	}
-	token = new_token(SUBSHELL_NEWLINE, l, newline_num, len_start);
+	if (l->is_subshell)
+		newline_type = SUBSHELL_NEWLINE;
+	else if (l->is_redirect)
+		newline_type = NEWLINE;
+	token = new_token(newline_type, l, newline_num, len_start);
 	return (token);
 }

--- a/lexer/lexer_utils.c
+++ b/lexer/lexer_utils.c
@@ -22,10 +22,11 @@ t_token	*skip_space(t_lexer *l)
 	token = NULL;
 	while (ft_isspace(l->ch))
 	{
-		if (l->is_subshell && l->ch == '\n')
+		if ((l->is_subshell || l->is_redirect) && l->ch == '\n')
 			token = new_token_newline(l);
 		read_char(l);
 	}
+	l->is_redirect = false;
 	if (l->ch == ')')
 	{
 		free(token);
@@ -38,4 +39,3 @@ int	is_digit(char c)
 {
 	return ('0' <= c && c <= '9');
 }
-

--- a/lexer/test/lexer_test.c
+++ b/lexer/test/lexer_test.c
@@ -52,6 +52,7 @@ char *debug_token_type[30] = {
 		"NOT_CLOSED",
 		"REDIRECT_MODIFIER",
 		"SUBSHELL_NEWLINE",
+		"NEWLINE",
 };
 
 void	compare_literal_and_type(char *input, char **debug_token_type, int expected_type, t_test *test);
@@ -568,6 +569,66 @@ int main()
 				{TEST_EOL, ""},
 		};
 		compare_literal_and_type(input, debug_token_type, LPAREN, test);
+	}
+
+	{
+		char input[] = "echo hello >\n cd ..";
+		struct test test[] = {
+				{STRING, "echo"},
+				{STRING, "hello"},
+				{REDIRECT_OUT, ">"},
+				{NEWLINE, "\n"},
+				{STRING, "cd"},
+				{STRING, ".."},
+				{EOL, "\0"},
+				{TEST_EOL, ""},
+		};
+		compare_literal_and_type(input, debug_token_type, NEWLINE, test);
+	}
+
+	{
+		char input[] = "echo hello <\n cd ..";
+		struct test test[] = {
+				{STRING, "echo"},
+				{STRING, "hello"},
+				{REDIRECT_IN, "<"},
+				{NEWLINE, "\n"},
+				{STRING, "cd"},
+				{STRING, ".."},
+				{EOL, "\0"},
+				{TEST_EOL, ""},
+		};
+		compare_literal_and_type(input, debug_token_type, NEWLINE, test);
+	}
+	{
+		char input[] = "echo hello >>\n\n cd ..";
+		struct test test[] = {
+				{STRING, "echo"},
+				{STRING, "hello"},
+				{REDIRECT_APPEND, ">>"},
+				{NEWLINE, "\n"},
+				{STRING, "cd"},
+				{STRING, ".."},
+				{EOL, "\0"},
+				{TEST_EOL, ""},
+		};
+		compare_literal_and_type(input, debug_token_type, NEWLINE, test);
+	}
+	{
+		char input[] = "echo hello <<\n end ||\n cd ..";
+		struct test test[] = {
+				{STRING, "echo"},
+				{STRING, "hello"},
+				{HEREDOC, "<<"},
+				{NEWLINE, "\n"},
+				{STRING, "end"},
+				{OR_IF, "||"},
+				{STRING, "cd"},
+				{STRING, ".."},
+				{EOL, "\0"},
+				{TEST_EOL, ""},
+		};
+		compare_literal_and_type(input, debug_token_type, NEWLINE, test);
 	}
 
 }

--- a/token/token.h
+++ b/token/token.h
@@ -30,6 +30,7 @@ typedef enum e_token_type {
 	NOT_CLOSED,
 	REDIRECT_MODIFIER,
 	SUBSHELL_NEWLINE,
+	NEWLINE,
 }	t_token_type;
 
 typedef struct s_string {


### PR DESCRIPTION
- Update: next_token() returns NEWLINE token only after redirection

## Purpose
リダイレクト後の改行だけサブシェル内でなくても `syntax error` になるため、`NEWLINE`tokenを返す必要がある。

## Effect
- リダイレクト後のみ`NEWLINE`tokenを返すことによって、parserの再帰条件分岐が楽になる。
- `SUBSHELL_NEWLINE` と `NEWLINE`でtokenを区別することで、どちらの`syntax error`か条件分岐しやすくなる？

## Test
```bash
$ pwd
/lexer/test
$ make
```

## Memo
こんな感じで、
- `HEREDOC`とかredirectionの後の改行は`NEWLINE`token返す。
- `OR_IF`とかの後の改行は解釈せずにスルーする。

っていうことができてるはず。

この変更に伴って、`t_lexer`構造体に、`bool is_redirect`という変数を追加した。
`is_redirect = true;`の場合のみ、`NEWLINE`tokenを返す。
```
input:echo hello <<
 end ||
 cd ..
{STRING, "echo"}
{STRING, "hello"}
{HEREDOC, "<<"}
{NEWLINE, ""}
{STRING, "end"}
{OR_IF, "||"}
{STRING, "cd"}
{STRING, ".."}
{EOL, ""}
```