### PR TITLE
lexerが環境変数`ENVIRONMENT`トークンをを返さないようした

### DIFF
--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -66,16 +66,6 @@ t_token *next_token(t_lexer *l)
 		else
 			token = new_token(ILLEGAL, l, 1, l->position);
 	}
-	else if (l->ch == '$')
-	{
-		if (!ft_strchr(DELIMITER, l->input[l->read_position]))
-		{
-			token = new_token_environment(l);
-			return (token);
-		}
-		else
-			token = new_token(ILLEGAL, l, 1, l->position);
-	}
 	else if (l->ch == '(')
 	{
 		token = new_token(LPAREN, l, 1, l->position);

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -15,7 +15,7 @@
 // todo: remove this
 # include "printf.h"
 
-# define DELIMITER "|&<>$() "
+# define DELIMITER "|&<>() "
 
 // todo: need to discuss if read_position is actually needed?
 // todo: type of positions are different from the book
@@ -49,7 +49,6 @@ int		is_digit(char c);
 // lexer_new_token.c
 t_token	*new_token(t_token_type token_type, t_lexer *l, size_t len, size_t start);
 t_token	*new_token_string(t_lexer *lexer);
-t_token	*new_token_environment(t_lexer *lexer);
 t_token	*new_token_redirect_or_string(t_lexer *lexer);
 t_token	*new_token_newline(t_lexer *lexer);
 

--- a/lexer/lexer_new_token.c
+++ b/lexer/lexer_new_token.c
@@ -48,28 +48,6 @@ t_token	*new_token_string(t_lexer *l)
 	return (token);
 }
 
-t_token	*new_token_environment(t_lexer *l)
-{
-	t_token			*token;
-	const size_t	len_start = l->position;
-
-	token = (t_token *)malloc(sizeof(t_token));
-	if (!token)
-		return (NULL);
-	read_char(l);
-	while (!ft_strchr(DELIMITER, l->ch))
-	{
-		read_char(l);
-		if (l->is_subshell && l->ch == '\n')
-			break ;
-	}
-	token->type = ENVIRONMENT;
-	token->literal.len = l->position - len_start;
-	token->literal.start = &(l->input[len_start]);
-	token->next = NULL;
-	return (token);
-}
-
 t_token	*new_token_redirect_or_string(t_lexer *l)
 {
 	t_token			*token;

--- a/parser/test/parser_test.c
+++ b/parser/test/parser_test.c
@@ -198,6 +198,22 @@ int main() {
 		test_parser(input, expected, AND_IF_NODE);
 	}
 	{
+		char input[] = "echo $TEST";
+		test expected[] = {
+				{COMMAND_ARG_NODE,      0, "echo"},
+				{COMMAND_ARG_NODE,      1, "$TEST"},
+		};
+		test_parser(input, expected, COMMAND_ARG_NODE);
+	}
+	{
+		char input[] = "e$TESTo hello";
+		test expected[] = {
+				{COMMAND_ARG_NODE,      0, "e$TESTo"},
+				{COMMAND_ARG_NODE,      1, "hello"},
+		};
+		test_parser(input, expected, COMMAND_ARG_NODE);
+	}
+	{
 		char input[] = "(echo hello";
 		test expected[] = {
 				{UNSET_NODE, 0, "minishell: syntax error: unexpected end of file\n"},


### PR DESCRIPTION
## Purpose
`$TEST`や`e$TESTo`のような環境変数だけor文字列の中に環境変数を含むものについて、全て`STRING`tokenで返すようにした。

## Effect
- parserの`word()`関数において、if分岐の中で一々`ENVIRONMENT`を確認しなくてよい。
```c
if (!consume_token(p, STRING, simple_command_element)
   && !consume_token(p, ENVIRONMENT, simple_command_element))
```

- 逆に`ENVIRONMENT`tokenを返してしまうと、以下のケースのようにnodeを上手く分けられない
```
input:echo $TEST
{Index: 0, Level: 0, Type:COMMAND_ARG_NODE, Literal:'echo'}
```

- expandの際にどうせ文字列を確認していくので、lexerの時点で`ENVIRONMENT`と認識する意味は薄い。
- `e$TESTo`みたいなパターンも一つの`STRING`tokenとして扱わないとexpansionが鬼難しくなる。

## Test
```bash
$ pwd
/parser/test
$ make
```

## Memo
以前、環境変数周りの扱いをちょろっと話し合った気がしますが、その時に直せてなかったです笑

大まかには、以下のようにlexerの処理変更したのでご確認ください！
```c
// lexer.c

t_token	*next_token(t_lexer *l)
{
	...
	else if (l->ch == '$') // 環境変数がきた時の分岐を消去
	{
		...
	}
	else
		new_token_string() // `STRING`tokenに統合
}
```
