### PR TITLE
#34 のレビュー内容変更、及び、`redirect*` の前の数字の対応削除

### DIFF
--- a/parser/parser.c
+++ b/parser/parser.c
@@ -106,6 +106,7 @@ t_ast_node *parse(t_token *token)
 		return (NULL);
 	root = command_line(p);
 	handle_err(p);
+	token_lstclear(p->token);
 	free(p);
 	return (root);
 }

--- a/parser/parser_utils.c
+++ b/parser/parser_utils.c
@@ -93,12 +93,14 @@ void	handle_err(t_parser *p)
 		write(STDERR_FILENO, "minishell: syntax error: unexpected end of file\n", 48);
 	else if (p->err == ERR_MALLOC)
 	{
-		perror("malloc"); // todo: is the exit status the same?
+		perror("malloc");
+		token_lstclear(p->token);
 		free(p);
 		exit(EXIT_FAILURE);
 	}
 	if (p->err)
 	{
+		token_lstclear(p->token);
 		free(p);
 		exit(EXIT_STATUS_PARSER);
 	}

--- a/parser/test/parser_test.c
+++ b/parser/test/parser_test.c
@@ -354,7 +354,6 @@ void test_parser(char input[], test *expected, int test_type, int expected_token
 		err_cnt++;
 		return;
 	}
-	token_lstclear(token);
 
 	if (test_type == ERROR_CASE) {
 		char *err_msg = (char *) res;


### PR DESCRIPTION
## Purpose

ノーマルチェックイン
- mallocエラー時の終了ステータスの設定 -> とりあえず`EXIT_FAILURE`
- parserの処理終了時のtoken free
- 以下のようなケースに対応しない（現状失敗するテストケース3つ追加）
```
echo hello 2> outfile
```

## Effect
- nodeの数が減る
- 課題で問われていない、余分な実装をする必要がなくなる

## Test
```
cd /parser/test; make
```
