### PR TITLE
リダイレクト前の`<number>`を`STRING`tokenとして返すようにした

### DIFF
--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -76,11 +76,6 @@ t_token *next_token(t_lexer *l)
 		token = new_token(RPAREN, l, 1, l->position);
 		l->is_subshell = false;
 	}
-	else if (is_digit(l->ch))
-	{
-		token = new_token_redirect_or_string(l);
-		return (token);
-	}
 	else if (l->ch == '\0')
 		token = new_token(EOL, l, 1, l->position);
 	else

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -44,12 +44,10 @@ t_token	*lex(char *input);
 // lexer_utils.c
 void	read_char(t_lexer *lexer);
 t_token	*skip_space(t_lexer *lexer);
-int		is_digit(char c);
 
 // lexer_new_token.c
 t_token	*new_token(t_token_type token_type, t_lexer *l, size_t len, size_t start);
 t_token	*new_token_string(t_lexer *lexer);
-t_token	*new_token_redirect_or_string(t_lexer *lexer);
 t_token	*new_token_newline(t_lexer *lexer);
 
 // lexer_list.c

--- a/lexer/lexer_new_token.c
+++ b/lexer/lexer_new_token.c
@@ -48,30 +48,6 @@ t_token	*new_token_string(t_lexer *l)
 	return (token);
 }
 
-t_token	*new_token_redirect_or_string(t_lexer *l)
-{
-	t_token			*token;
-	const size_t	len_start = l->position;
-	size_t			digits;
-
-	digits = 0;
-	while (is_digit(l->ch))
-	{
-		read_char(l);
-		digits++;
-	}
-	if (l->ch == '<' || l->ch == '>')
-		token = new_token(REDIRECT_MODIFIER, l, digits, len_start);
-	else
-	{
-		l->position = len_start;
-		l->read_position = len_start + 1;
-		l->ch = l->input[len_start];
-		token = new_token_string(l);
-	}
-	return (token);
-}
-
 t_token	*new_token_newline(t_lexer *l)
 {
 	t_token			*token;

--- a/lexer/lexer_utils.c
+++ b/lexer/lexer_utils.c
@@ -34,8 +34,3 @@ t_token	*skip_space(t_lexer *l)
 	}
 	return (token);
 }
-
-int	is_digit(char c)
-{
-	return ('0' <= c && c <= '9');
-}

--- a/lexer/test/lexer_test.c
+++ b/lexer/test/lexer_test.c
@@ -166,8 +166,7 @@ int main()
 	{
 		char input[] = "echo$HELLO";
 		struct test test[] = {
-				{STRING, "echo"},
-				{ENVIRONMENT, "$HELLO"},
+				{STRING, "echo$HELLO"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},
 		};
@@ -245,7 +244,7 @@ int main()
 		struct test test[] = {
 				{LPAREN, "("},
 				{STRING, "echo"},
-				{ENVIRONMENT, "$PATH"},
+				{STRING, "$PATH"},
 				{RPAREN, ")"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},
@@ -307,7 +306,7 @@ int main()
 		struct test test[] = {
 				{STRING, "echo"},
 				{STRING, "hello"},
-				{REDIRECT_MODIFIER, "1"},
+				{STRING, "1"},
 				{REDIRECT_OUT, ">"},
 				{STRING, "res"},
 				{EOL, "\0"},
@@ -321,7 +320,7 @@ int main()
 		struct test test[] = {
 				{STRING, "echo"},
 				{STRING, "hello"},
-				{REDIRECT_MODIFIER, "100"},
+				{STRING, "100"},
 				{REDIRECT_OUT, ">"},
 				{STRING, "res"},
 				{EOL, "\0"},
@@ -364,7 +363,7 @@ int main()
 		struct test test[] = {
 				{STRING, "echo"},
 				{STRING, "hello"},
-				{REDIRECT_MODIFIER, "2"},
+				{STRING, "2"},
 				{REDIRECT_IN, "<"},
 				{STRING, "res"},
 				{EOL, "\0"},
@@ -378,7 +377,7 @@ int main()
 		struct test test[] = {
 				{STRING, "echo"},
 				{STRING, "hello"},
-				{REDIRECT_MODIFIER, "200"},
+				{STRING, "200"},
 				{REDIRECT_IN, "<"},
 				{STRING, "res"},
 				{EOL, "\0"},
@@ -420,7 +419,7 @@ int main()
 		struct test test[] = {
 				{STRING, "echo"},
 				{STRING, "hello"},
-				{REDIRECT_MODIFIER, "3"},
+				{STRING, "3"},
 				{HEREDOC, "<<"},
 				{STRING, "res"},
 				{EOL, "\0"},
@@ -462,7 +461,7 @@ int main()
 		struct test test[] = {
 				{STRING, "echo"},
 				{STRING, "hello"},
-				{REDIRECT_MODIFIER, "4"},
+				{STRING, "4"},
 				{REDIRECT_APPEND, ">>"},
 				{STRING, "res"},
 				{EOL, "\0"},
@@ -533,7 +532,7 @@ int main()
 				{SUBSHELL_NEWLINE, "\n\n"},
 				{STRING, "echo"},
 				{SUBSHELL_NEWLINE, "\n"},
-				{ENVIRONMENT, "$PATH"},
+				{STRING, "$PATH"},
 				{RPAREN, ")"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},


### PR DESCRIPTION
## Purpose
`<num> '>' <word>`のようなケースは今回の課題において対応する必要がないため、`STRING`トークンとして返すようにした。

## Effect
課題で対応しなくてよい文字列を全て`STRING`トークンで返すことにより、parser以降の処理が単純になる。

## Test
```bash
$ pwd
/lexer/test
$ make
```

## Test Environment

### Hardware

ex: PC(Windows) / PC(Mac) / Raspberry Pi/ Jetson Nano

### Software(Library)

ex: TensorFlow==1.15.3...

## Memo
ほぼ全ての文字列を`STRING`で返すようになりました笑
