### PR TITLE
【軽PR】`lexerr_internal.h`に変更

### DIFF
--- a/lexer/internal/lexer_internal.h
+++ b/lexer/internal/lexer_internal.h
@@ -1,6 +1,5 @@
-#ifndef INTERNAL_H
-# define INTERNAL_H
-
+#ifndef LEXER_INTERNAL_H
+# define LEXER_INTERNAL_H
 # include <stdlib.h>
 # include <stdio.h>
 # include <stdbool.h>

--- a/lexer/internal/lexer_new_token.c
+++ b/lexer/internal/lexer_new_token.c
@@ -1,4 +1,4 @@
-#include "internal.h"
+#include "lexer_internal.h"
 
 t_token	*new_token(t_token_type token_type, t_lexer *l, size_t len, size_t len_start)
 {

--- a/lexer/internal/lexer_utils.c
+++ b/lexer/internal/lexer_utils.c
@@ -1,4 +1,4 @@
-#include "internal.h"
+#include "lexer_internal.h"
 
 void	new_lexer(t_lexer **l, char *input)
 {

--- a/lexer/internal/next_token.c
+++ b/lexer/internal/next_token.c
@@ -1,4 +1,4 @@
-#include "internal.h"
+#include "lexer_internal.h"
 
 t_token *next_token(t_lexer *l)
 {

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -2,7 +2,7 @@
 # define LEXER_H
 
 # include "../token/token.h"
-# include "internal/internal.h"
+# include "internal/lexer_internal.h"
 
 // lex.c
 t_token	*lex(char *input);


### PR DESCRIPTION
## Purpose
- コンパイル時に名前衝突しないように`lexer_internal.h`に改名しました。