### PR TITLE
【軽バグ】compound_list内でenv_varsを与えるよう修正

### DIFF
--- a/execute/internal/execute_command.c
+++ b/execute/internal/execute_command.c
@@ -36,6 +36,7 @@ int	execute_compound_list(t_executor *e, t_compound_list *cl)
 	{
 		new_executor(&exe_child, NULL);
 		exe_child->pipeline = cl->pipeline;
+		exe_child->env_vars = e->env_vars;
 		exit_status = execute_pipeline(exe_child, exe_child->pipeline);
 		if (cl->compound_list_next)
 			eval_compound_list(e, &cl->next, cl->compound_list_next);


### PR DESCRIPTION
## Purpose

`compound_list`内で`env_vars`を新しく作成した`t_executor`に渡しておらず、segvしていたのを修正。