### PR TITLE
サブシェルがネストした時にsyntax errorが出てしまっていたのを修正

### DIFF
--- a/parser/internal/command_line.c
+++ b/parser/internal/command_line.c
@@ -97,15 +97,16 @@ t_ast_node	*subshell(t_parser *p)
 {
 	t_ast_node	*result;
 	t_ast_node	*compound_list_;
+	static int	subshell_level;
 
 	if (!consume_token(p, LPAREN, NULL))
 		return (NULL);
+	subshell_level++;
 	p->is_subshell = true;
 	consume_token(p, SUBSHELL_NEWLINE_MS, NULL);
 	if (!assign_ast_node(&compound_list_, compound_list(p)))
 	{
-		if (!p->err)
-			p->err = ERR_UNEXPECTED_EOF;
+		!p->err && (p->err = ERR_UNEXPECTED_EOF);
 		return (NULL);
 	}
 	if (!consume_token(p, RPAREN, NULL))
@@ -113,7 +114,8 @@ t_ast_node	*subshell(t_parser *p)
 		p->err = ERR_UNEXPECTED_EOF;
 		return (delete_ast_nodes(compound_list_, NULL));
 	}
-	p->is_subshell = false;
+	if (--subshell_level == 0)
+		p->is_subshell = false;
 	new_ast_node(&result);
 	result->type = SUBSHELL_NODE;
 	set_ast_nodes(result, compound_list_, NULL);

--- a/parser/internal/parser_utils.c
+++ b/parser/internal/parser_utils.c
@@ -23,11 +23,7 @@ bool	consume_token(t_parser *p, t_token_type expected, t_ast_node *node)
 	if (p->token->type != expected)
 		return (false);
 	if (node)
-	{
-		node->data = ft_strndup(p->token->literal.start, p->token->literal.len);
-		if (!node->data)
-			perror_exit("malloc", EXIT_FAILURE);
-	}
+		node->data = x_strndup(p->token->literal.start, p->token->literal.len);
 	p->token = p->token->next;
 	return (true);
 }

--- a/parser/test/parser_test.c
+++ b/parser/test/parser_test.c
@@ -349,6 +349,25 @@ int main() {
 		};
 		test_parser(input, expected, ERROR_CASE, 0);
 	}
+	{
+		char input[] = "(cat xxxx || (cat xxxx || echo ok) && echo $?)";
+		test expected[] = {
+				{SUBSHELL_NODE,    0, ""},
+				{OR_IF_NODE,       1, ""},
+				{COMMAND_ARG_NODE, 2, "cat"},
+				{COMMAND_ARG_NODE, 3, "xxxx"},
+				{AND_IF_NODE,      2, ""},
+				{SUBSHELL_NODE,    3, ""},
+				{OR_IF_NODE,       4, ""},
+				{COMMAND_ARG_NODE, 5, "cat"},
+				{COMMAND_ARG_NODE, 6, "xxxx"},
+				{COMMAND_ARG_NODE, 5, "echo"},
+				{COMMAND_ARG_NODE, 6, "ok"},
+				{COMMAND_ARG_NODE, 3, "echo"},
+				{COMMAND_ARG_NODE, 4, "$?"},
+		};
+		test_parser(input, expected, SUBSHELL_NODE, sizeof(expected) / sizeof(test));
+	}
 
 	print_err_cnt();
 //	system("leaks a.out");

--- a/test/cases/subshell.txt
+++ b/test/cases/subshell.txt
@@ -29,7 +29,7 @@ echo $?
 echo $?
 (cat xxxx || echo b && echo $?)
 echo $?
-echo "(cat xxxx || (cat xxxx || echo ok) && echo $?)"
+(cat xxxx || (cat xxxx || echo ok) && echo $?)
 echo $?
 pwd && (pwd && cd .. && pwd) && pwd
 ls && (ls && cd .. && ls) && ls


### PR DESCRIPTION
## Purpose
以下のように`subshell`がネストした時に、`is_subshell`だけを使っていると対応できないので、`subshell`の深さを変数を用いて管理するように変更
```
(cat xxxx || (cat xxxx || echo ok) && echo $?)
```

## Test Command
```
$ cd /parser/test
$ make
```
