### PR TITLE
使用禁止関数の置き換え

### DIFF
--- a/expander/internal/expander_wildcard_lst.c
+++ b/expander/internal/expander_wildcard_lst.c
@@ -18,7 +18,7 @@ static t_wildcard	*init_pattern_list(const char *data, t_wildcard *prev)
 	t_wildcard	*new;
 
 	new = malloc(sizeof(*new));
-	new->data = strdup(data);
+	new->data = x_strdup(data);
 	new->prev = prev;
 	new->next = NULL;
 	if (prev)


### PR DESCRIPTION
## Purpose
- 使用禁止関数の置き換え

## Effect
- `strdup` -> `x_strdup`

