### PR TITLE
heredocのdelimのexpandを修正

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -13,11 +13,13 @@ static void	search_expandable_node(t_expander *e, t_ast_node *node)
 	if (node->type != COMMAND_ARG_NODE
 		&& node->type != REDIRECT_IN_NODE
 		&& node->type != REDIRECT_OUT_NODE
-		&& node->type != REDIRECT_APPEND_NODE)
+		&& node->type != REDIRECT_APPEND_NODE
+		&& node->type != HEREDOC_NODE)
 		return ;
 	original_right = node->right;
 	original_data = x_strdup(node->data);
-	node->data = variable_expansion(e, node->data);
+	if (node->type != HEREDOC_NODE)
+		node->data = variable_expansion(e, node->data);
 	if (!is_empty_data(e, node, original_data))
 	{
 		word_splitting(node, e, original_data, original_right);

--- a/expander/internal/expander_word_splitting.c
+++ b/expander/internal/expander_word_splitting.c
@@ -91,7 +91,8 @@ static bool	split_arg_node(char **split, t_ast_node *node,
 	{
 		if (i == 0)
 		{
-			if (node->type != COMMAND_ARG_NODE && ft_strcmp(split[i], expanded))
+			if (node->type != COMMAND_ARG_NODE && node->type != HEREDOC_NODE
+				&& ft_strcmp(split[i], expanded))
 				return (false);
 			free(node->data);
 			node->data = split[i];


### PR DESCRIPTION
## Purpose
- 以前は、`HEREDOC_NODE`がexpanderに渡された際には、何も展開しないようにしていた。
- しかし、以下のようなケースでは、クオートを除去してからheredocの処理を行わなければならないことが判明した。
```bash
# OK
$ cat << T""
> T
$

# NG
$ cat << T""
> T
> T""
T
$
```

- また、上記と似たような以下のケースでも、heredocでの展開方法を間違えてしまうと、他のリダイレクトのようにエラーを設定してしまっていた。
```bash
# OK
$ echo hello << T""
> T
hello

#NG
$ echo hello << T""
minishell: T"": ambiguous redirect
```
## Effect
- 上記のエラーケースに対応するため、`expander`における処理を若干修正した。
- `HEREDOC_NODE`が渡された際にも、一部の展開は行うようにした。

## MEMO
もうちょっと上手く書こうとしたらバグり散らかしたので、このぐらいの修正しかできませんでした。。。